### PR TITLE
Fix plus plus

### DIFF
--- a/src/components/stats/playerinfo.svelte
+++ b/src/components/stats/playerinfo.svelte
@@ -17,7 +17,8 @@
 
 	const playerData = player.player;
 
-	const rank = getRankDefaults(playerData.rank ?? playerData.newPackageRank);
+	const rankName = (playerData.monthlyPackageRank === 'SUPERSTAR') ? 'SUPERSTAR' : (playerData.rank ?? playerData.newPackageRank);
+	const rank = getRankDefaults(rankName);
 	const plus = rank?.plus ?? undefined;
 	const plusColor = rank?.plusColor;
 </script>

--- a/src/lib/constants/data.ts
+++ b/src/lib/constants/data.ts
@@ -65,6 +65,7 @@ export const KEPT_PLAYER_FIELDS = [
 	'rank',
 	'rankPlusColor',
 	'newPackageRank',
+	'monthlyPackageRank',
 	'userLanguage',
 	'skyblock_extra',
 	'scorpius_bribe_',

--- a/src/lib/skyblock.d.ts
+++ b/src/lib/skyblock.d.ts
@@ -305,6 +305,7 @@ export interface PlayerData {
 	karma: number;
 	rank?: RankName;
 	newPackageRank?: RankName;
+	monthlyPackageRank?: 'NONE' | 'SUPERSTAR';
 	rankPlusColor?: PlusColor;
 	socialMedia?: {
 		links?: {


### PR DESCRIPTION
Fixes #31 

Keeps the `monthlyPackageRank` field from the API and prioritizes showing it over the alternatives.