### PR TITLE
Use new cookies.set instead of adding headers

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -29,12 +29,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.discordUser = discordUser;
 	event.locals.user = user;
 
-	if (cookies) for (const { name, value, expires } of cookies) {
-		event.cookies.set(name, value, {
-			path: '/',
-			expires: new Date(expires),
-		});
-	}
+	if (cookies)
+		for (const { name, value, expires } of cookies) {
+			event.cookies.set(name, value, {
+				path: '/',
+				expires: new Date(expires),
+			});
+		}
 
 	return await resolve(event);
 };
@@ -51,7 +52,7 @@ async function getUser(locals: App.Locals): Promise<{ session: App.Session; cook
 	if (locals.discord_access_token) {
 		const data = await fetchUser(locals.discord_access_token);
 		if (data.session.discordUser) return data;
-		
+
 		if (locals.discord_refresh_token) {
 			return refreshUser(locals.discord_refresh_token);
 		}
@@ -89,7 +90,7 @@ async function fetchUser(token: string): Promise<{ session: App.Session; cookies
 }
 
 async function refreshUser(token: string): Promise<{ session: App.Session; cookies?: CookieData[] }> {
-	const failure: { session: App.Session, cookies?: CookieData[] } = { session: { discordUser: false, user: false } };
+	const failure: { session: App.Session; cookies?: CookieData[] } = { session: { discordUser: false, user: false } };
 	const discord_request = await fetch(`${HOST}/api/refresh?code=${token}`);
 
 	try {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,12 @@ import { PUBLIC_DISCORD_URL as DISCORD_API_URL, PUBLIC_HOST_URL as HOST } from '
 import { GetUserByDiscordID, UpdateDiscordUser } from '$db/database';
 import type { DiscordUser } from '$db/models/users';
 
+interface CookieData {
+	name: string;
+	value: string;
+	expires: string;
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
 	const browserCookies = cookie.parse(event.request.headers.get('cookie') ?? '');
 
@@ -23,18 +29,17 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.discordUser = discordUser;
 	event.locals.user = user;
 
-	const response = await resolve(event);
-
-	if (cookies) {
-		for (const cookie of cookies) {
-			response.headers.append('Set-Cookie', cookie);
-		}
+	if (cookies) for (const { name, value, expires } of cookies) {
+		event.cookies.set(name, value, {
+			path: '/',
+			expires: new Date(expires),
+		});
 	}
 
-	return response;
+	return await resolve(event);
 };
 
-async function getUser(locals: App.Locals): Promise<{ session: App.Session; cookies?: string[] }> {
+async function getUser(locals: App.Locals): Promise<{ session: App.Session; cookies?: CookieData[] }> {
 	if (!locals.discord_access_token && !locals.discord_refresh_token) {
 		return { session: { discordUser: false, user: false } };
 	}
@@ -44,7 +49,12 @@ async function getUser(locals: App.Locals): Promise<{ session: App.Session; cook
 	}
 
 	if (locals.discord_access_token) {
-		return fetchUser(locals.discord_access_token);
+		const data = await fetchUser(locals.discord_access_token);
+		if (data.session.discordUser) return data;
+		
+		if (locals.discord_refresh_token) {
+			return refreshUser(locals.discord_refresh_token);
+		}
 	}
 
 	// not authenticated, return empty user object
@@ -56,7 +66,7 @@ async function getUser(locals: App.Locals): Promise<{ session: App.Session; cook
 	};
 }
 
-async function fetchUser(token: string): Promise<{ session: App.Session; cookies?: string[] }> {
+async function fetchUser(token: string): Promise<{ session: App.Session; cookies?: CookieData[] }> {
 	const request = await fetch(`${DISCORD_API_URL}/users/@me`, {
 		headers: { Authorization: `Bearer ${token}` },
 	});
@@ -78,18 +88,17 @@ async function fetchUser(token: string): Promise<{ session: App.Session; cookies
 	}
 }
 
-async function refreshUser(token: string): Promise<{ session: App.Session; cookies?: string[] }> {
-	const failure: { session: App.Session } = { session: { discordUser: false, user: false } };
+async function refreshUser(token: string): Promise<{ session: App.Session; cookies?: CookieData[] }> {
+	const failure: { session: App.Session, cookies?: CookieData[] } = { session: { discordUser: false, user: false } };
 	const discord_request = await fetch(`${HOST}/api/refresh?code=${token}`);
-
-	if (discord_request.status !== 200) return failure;
 
 	try {
 		const discord_response = (await discord_request.json()) as {
 			discord_access_token: string;
-			discord_refresh_token: string;
-			cookies: string[];
+			cookies: CookieData[];
 		};
+
+		failure.cookies = discord_response.cookies;
 
 		if (!discord_response.discord_access_token) return failure;
 

--- a/src/routes/api/refresh/+server.ts
+++ b/src/routes/api/refresh/+server.ts
@@ -57,12 +57,8 @@ export const GET: RequestHandler = async ({ url }) => {
 		JSON.stringify({
 			discord_access_token: response.access_token,
 			cookies: [
-				`discord_access_token=${
-					response.access_token
-				}; Expires=${accessTokenExpires.toUTCString()}; Path=/; HttpOnly; SameSite=Strict;`,
-				`discord_refresh_token=${
-					response.refresh_token
-				}; Expires=${refreshTokenExpires.toUTCString()}; Path=/; HttpOnly; SameSite=Strict;`,
+				{ name: 'discord_access_token', value: response.access_token, expires: accessTokenExpires.toUTCString() },
+				{ name: 'discord_refresh_token', value: response.refresh_token, expires: refreshTokenExpires.toUTCString() },
 			],
 		})
 	);

--- a/src/routes/api/refresh/+server.ts
+++ b/src/routes/api/refresh/+server.ts
@@ -57,8 +57,16 @@ export const GET: RequestHandler = async ({ url }) => {
 		JSON.stringify({
 			discord_access_token: response.access_token,
 			cookies: [
-				{ name: 'discord_access_token', value: response.access_token, expires: accessTokenExpires.toUTCString() },
-				{ name: 'discord_refresh_token', value: response.refresh_token, expires: refreshTokenExpires.toUTCString() },
+				{
+					name: 'discord_access_token',
+					value: response.access_token,
+					expires: accessTokenExpires.toUTCString(),
+				},
+				{
+					name: 'discord_refresh_token',
+					value: response.refresh_token,
+					expires: refreshTokenExpires.toUTCString(),
+				},
 			],
 		})
 	);


### PR DESCRIPTION
Fixes #61 

Uses new `cookies.set()` syntax instead of adding headers to the response body manually.