### PR TITLE
Mushroom Weight

### DIFF
--- a/src/lib/weight.ts
+++ b/src/lib/weight.ts
@@ -114,7 +114,7 @@ export function calcCollections(member: ProfileMember) {
 	const normalRatio = (total - cactus - cane) / total;
 
 	const mushWght = CROPS_PER_ONE_WEIGHT.mushroom;
-	const mushroomWeight = (doubleBreakRatio * (MUSHROOM / (2 * mushWght))) + (normalRatio * (MUSHROOM / mushWght));
+	const mushroomWeight = doubleBreakRatio * (MUSHROOM / (2 * mushWght)) + normalRatio * (MUSHROOM / mushWght);
 
 	collections.set('Mushroom', RoundToFixed(mushroomWeight));
 

--- a/src/lib/weight.ts
+++ b/src/lib/weight.ts
@@ -56,7 +56,7 @@ export function CalculateWeight(profiles: ProfileData[], highest?: HighestWeight
 export function calcCollections(member: ProfileMember) {
 	if (!member.collection) return undefined;
 
-	const {
+	let {
 		WHEAT,
 		POTATO_ITEM: POTATO,
 		CARROT_ITEM: CARROT,
@@ -68,21 +68,55 @@ export function calcCollections(member: ProfileMember) {
 		NETHER_STALK: WART,
 	} = member.collection;
 
-	const COCOA = member.collection['INK_SACK:3']; // Dumb cocoa
+	let COCOA = member.collection['INK_SACK:3']; // Dumb cocoa
+
+	if (isNaN(WHEAT)) WHEAT = 0;
+	if (isNaN(POTATO)) POTATO = 0;
+	if (isNaN(CARROT)) CARROT = 0;
+	if (isNaN(MUSHROOM)) MUSHROOM = 0;
+	if (isNaN(PUMPKIN)) PUMPKIN = 0;
+	if (isNaN(MELON)) MELON = 0;
+	if (isNaN(CANE)) CANE = 0;
+	if (isNaN(CACTUS)) CACTUS = 0;
+	if (isNaN(WART)) WART = 0;
+	if (isNaN(COCOA)) COCOA = 0;
 
 	const collections = new Map<string, number>();
 
+	const wheat = WHEAT / CROPS_PER_ONE_WEIGHT.wheat;
+	const potato = POTATO / CROPS_PER_ONE_WEIGHT.potato;
+	const carrot = CARROT / CROPS_PER_ONE_WEIGHT.carrot;
+	const mushroom = MUSHROOM / CROPS_PER_ONE_WEIGHT.mushroom;
+	const pumpkin = PUMPKIN / CROPS_PER_ONE_WEIGHT.pumpkin;
+	const melon = MELON / CROPS_PER_ONE_WEIGHT.melon;
+	const cane = CANE / CROPS_PER_ONE_WEIGHT.sugarcane;
+	const cactus = CACTUS / CROPS_PER_ONE_WEIGHT.cactus;
+	const wart = WART / CROPS_PER_ONE_WEIGHT.netherwart;
+	const cocoa = COCOA / CROPS_PER_ONE_WEIGHT.cocoa;
+
 	//Normalize collections
-	collections.set('Wheat', RoundToFixed(WHEAT / CROPS_PER_ONE_WEIGHT.wheat));
-	collections.set('Carrot', RoundToFixed(CARROT / CROPS_PER_ONE_WEIGHT.carrot));
-	collections.set('Potato', RoundToFixed(POTATO / CROPS_PER_ONE_WEIGHT.potato));
-	collections.set('Pumpkin', RoundToFixed(PUMPKIN / CROPS_PER_ONE_WEIGHT.pumpkin));
-	collections.set('Melon', RoundToFixed(MELON / CROPS_PER_ONE_WEIGHT.melon));
-	collections.set('Mushroom', RoundToFixed(MUSHROOM / CROPS_PER_ONE_WEIGHT.mushroom));
-	collections.set('Cocoa Beans', RoundToFixed(COCOA / CROPS_PER_ONE_WEIGHT.cocoa));
-	collections.set('Cactus', RoundToFixed(CACTUS / CROPS_PER_ONE_WEIGHT.cactus));
-	collections.set('Sugar Cane', RoundToFixed(CANE / CROPS_PER_ONE_WEIGHT.sugarcane));
-	collections.set('Nether Wart', RoundToFixed(WART / CROPS_PER_ONE_WEIGHT.netherwart));
+	collections.set('Wheat', RoundToFixed(wheat));
+	collections.set('Carrot', RoundToFixed(carrot));
+	collections.set('Potato', RoundToFixed(potato));
+	collections.set('Pumpkin', RoundToFixed(pumpkin));
+	collections.set('Melon', RoundToFixed(melon));
+	collections.set('Cocoa Beans', RoundToFixed(cocoa));
+	collections.set('Cactus', RoundToFixed(cactus));
+	collections.set('Sugar Cane', RoundToFixed(cane));
+	collections.set('Nether Wart', RoundToFixed(wart));
+
+	// Mushroom is a special case, it needs to be calculated dynamically based on the
+	// ratio between the farmed crops that give two mushrooms per break with cow pet
+	// and the farmed crops that give one mushroom per break with cow pet
+	const total = wheat + carrot + potato + pumpkin + melon + cocoa + cactus + cane + wart + mushroom;
+
+	const doubleBreakRatio = (cactus + cane) / total;
+	const normalRatio = (total - cactus - cane) / total;
+
+	const mushWght = CROPS_PER_ONE_WEIGHT.mushroom;
+	const mushroomWeight = (doubleBreakRatio * (MUSHROOM / (2 * mushWght))) + (normalRatio * (MUSHROOM / mushWght));
+
+	collections.set('Mushroom', RoundToFixed(mushroomWeight));
 
 	return collections;
 }

--- a/src/routes/info/+page.svelte
+++ b/src/routes/info/+page.svelte
@@ -37,12 +37,18 @@
 				needed to increase your farming weight by 1.
 			</p>
 			<CropTable />
-			<p class="text-sm my-4">
+			<p class="text-sm mt-4 mb-2">
 				Base Drops Per Break refers to the average amount of drops you get from breaking a crop without any
 				buffs. Sugar Cane and Cactus actually have a base drop of 1 per block, but because you can break 2
 				blocks at once, 2 is noted here. Mushroom is also nerfed more to make up for the Mooshroom cow perk; one
 				hour of perfect farming would net you an extra one weight with the current value. Full calculation
 				breakdowns will be added in the future.
+			</p>
+			<p class="text-sm">
+				* Mushroom weight is calculated dynamically because of the Mooshroom Cow pet. Because Cactus and Sugar Cane
+				are both 2 blocks per break, the cow's perk gives you twice the normal rate of mushroom drops than from 
+				other crops. To counter this, you get half the weight from mushrooms for the ratio of Cactus and Sugar Cane
+				farmed out of the total weight, and the remainder is calculated normally.
 			</p>
 		</article>
 	</section>

--- a/src/routes/info/+page.svelte
+++ b/src/routes/info/+page.svelte
@@ -45,10 +45,10 @@
 				breakdowns will be added in the future.
 			</p>
 			<p class="text-sm">
-				* Mushroom weight is calculated dynamically because of the Mooshroom Cow pet. Because Cactus and Sugar Cane
-				are both 2 blocks per break, the cow's perk gives you twice the normal rate of mushroom drops than from 
-				other crops. To counter this, you get half the weight from mushrooms for the ratio of Cactus and Sugar Cane
-				farmed out of the total weight, and the remainder is calculated normally.
+				* Mushroom weight is calculated dynamically because of the Mooshroom Cow pet. Because Cactus and Sugar
+				Cane are both 2 blocks per break, the cow's perk gives you twice the normal rate of mushroom drops than
+				from other crops. To counter this, you get half the weight from mushrooms for the ratio of Cactus and
+				Sugar Cane farmed out of the total weight, and the remainder is calculated normally.
 			</p>
 		</article>
 	</section>

--- a/src/routes/info/croptable.svelte
+++ b/src/routes/info/croptable.svelte
@@ -33,7 +33,11 @@
 		</tr>
 		<tr class="bg-gray-100 dark:bg-zinc-800">
 			<td>Mushroom</td>
-			<td>{crops['mushroom'].toLocaleString(undefined, { maximumFractionDigits: 0 })} - {(crops['mushroom'] * 2).toLocaleString(undefined, { maximumFractionDigits: 0 })}*</td>
+			<td
+				>{crops['mushroom'].toLocaleString(undefined, { maximumFractionDigits: 0 })} - {(
+					crops['mushroom'] * 2
+				).toLocaleString(undefined, { maximumFractionDigits: 0 })}*</td
+			>
 			<td>1</td>
 		</tr>
 		<tr class="bg-gray-100 dark:bg-zinc-800">

--- a/src/routes/info/croptable.svelte
+++ b/src/routes/info/croptable.svelte
@@ -33,7 +33,7 @@
 		</tr>
 		<tr class="bg-gray-100 dark:bg-zinc-800">
 			<td>Mushroom</td>
-			<td>{crops['mushroom'].toLocaleString(undefined, { maximumFractionDigits: 0 })}</td>
+			<td>{crops['mushroom'].toLocaleString(undefined, { maximumFractionDigits: 0 })} - {(crops['mushroom'] * 2).toLocaleString(undefined, { maximumFractionDigits: 0 })}*</td>
 			<td>1</td>
 		</tr>
 		<tr class="bg-gray-100 dark:bg-zinc-800">


### PR DESCRIPTION
Mushroom weight is calculated dynamically because of the Mooshroom Cow pet. Because Cactus and Sugar Cane are both 2 blocks per break, the cow's perk gives you twice the normal rate of mushroom drops than from other crops. To counter this, you get half the weight from mushrooms for the ratio of Cactus and Sugar Cane farmed out of the total weight, and the remainder is calculated normally.

This change is a mild nerf, and it shouldn't affect overall player weights that much overall.