### PR TITLE
Fix leaderboard ordering

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -252,10 +252,13 @@ export async function FetchWeightLeaderboard() {
 		limit: 1_000,
 		attributes: {
 			exclude: ['id', 'account', 'player', 'skyblock', 'user', 'createdAt', 'updatedAt', 'info'],
-			include: [[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming'), 'farming']],
+			include: [
+				[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming', 'profile'), 'profile'],
+				[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming', 'weight'), 'weight']
+			],
 		},
 		where: { ['info.cheating']: { [Op.not]: true }, ['info.highest.farming.weight']: { [Op.gt]: 0 } },
-		order: [[sequelize.literal('farming'), 'DESC']],
+		order: [[sequelize.literal('weight'), 'DESC']],
 		raw: true,
 		nest: true,
 	});

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -214,10 +214,8 @@ export interface LeaderboardEntry {
 	uuid: string;
 	ign: string;
 	rank: number;
-	farming: {
-		weight: number;
-		profile: string;
-	};
+	weight: number;
+	profile: string;
 }
 
 export async function GetPlayerRank(uuid: string) {
@@ -254,7 +252,7 @@ export async function FetchWeightLeaderboard() {
 			exclude: ['id', 'account', 'player', 'skyblock', 'user', 'createdAt', 'updatedAt', 'info'],
 			include: [
 				[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming', 'profile'), 'profile'],
-				[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming', 'weight'), 'weight']
+				[sequelize.fn('jsonb_extract_path', sequelize.col('info'), 'highest', 'farming', 'weight'), 'weight'],
 			],
 		},
 		where: { ['info.cheating']: { [Op.not]: true }, ['info.highest.farming.weight']: { [Op.gt]: 0 } },

--- a/src/routes/leaderboard/entry.svelte
+++ b/src/routes/leaderboard/entry.svelte
@@ -6,7 +6,7 @@
 
 	const highlight = entry.ign === jump;
 
-	const { ign, farming, uuid } = entry;
+	const { ign, weight, profile, uuid } = entry;
 </script>
 
 <div
@@ -24,11 +24,11 @@
 	</div>
 	<div class="flex gap-2 p-1 justify-end align-middle">
 		<div class="text-sm sm:text-xl">
-			{farming.weight.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}
+			{weight.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}
 		</div>
 		<div>
 			<a
-				href="/stats/{uuid}/{farming.profile}"
+				href="/stats/{uuid}/{profile}"
 				class="text-blue-600 bg-gray-300 dark:bg-zinc-800 p-1 sm:p-2 ml-1 rounded-md text-md sm:text-lg"
 			>
 				Stats

--- a/src/routes/stats/[id]/[profile]/+page.ts
+++ b/src/routes/stats/[id]/[profile]/+page.ts
@@ -63,7 +63,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 			}));
 		profileIds.unshift({ id: profile.profile_id, name: profile.cute_name });
 
-		const weightFetch = await fetch(`/api/weight/${account.id}/${profileId}`);
+		const weightFetch = await fetch(`/api/weight/${account.id}/${profile.profile_id}`);
 		const weight = (await weightFetch.json()) as WeightInfo;
 
 		return {


### PR DESCRIPTION
Previous database query sorted the whole `farming:` field, with the addition of `crop:` this was messed up. 

The ordering now uses a correct sort by weight value, but at the cost of a slower query.