### PR TITLE
Api Access Data in Weight Info

### DIFF
--- a/src/database/models/users.ts
+++ b/src/database/models/users.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo, PlayerInfo, Profiles } from '$lib/skyblock.d';
+import type { AccountInfo, APISettings, PlayerInfo, Profiles } from '$lib/skyblock.d';
 import { DataTypes, Model, Sequelize } from 'sequelize';
 import type {
 	CreationOptional,
@@ -36,6 +36,7 @@ export interface WeightBreakdown {
 
 export interface WeightInfo {
 	farming: WeightBreakdown;
+	api: APISettings;
 	cute_name: string;
 }
 

--- a/src/lib/weight.ts
+++ b/src/lib/weight.ts
@@ -50,6 +50,7 @@ export function CalculateWeight(profiles: ProfileData[], highest?: HighestWeight
 				sources: sources,
 				bonuses: bonuses,
 			},
+			api: profile.api,
 			cute_name: profile.cute_name,
 		};
 


### PR DESCRIPTION
Adds the `APISettings` object to each profile in the `/weight/<uuid>` endpoint. This is useful for easily checking/displaying this data without needing to retrieve the full profile response.