### PR TITLE
Fetch Account By Discord

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -152,6 +152,13 @@ export function UpdateDiscordUser(id: string, user: DiscordUser) {
 	return UpdateUser({ id: id }, { user: user });
 }
 
+export async function GetAccountFromDiscord(id: string) {
+	const user = await GetUserByDiscordID(id);
+	if (!user) return null;
+
+	return user.account;
+}
+
 export async function GetAccountData(uuid: string) {
 	const user = await GetUser(uuid);
 	return user?.account ?? null;

--- a/src/routes/api/account/discord/[id]/+server.ts
+++ b/src/routes/api/account/discord/[id]/+server.ts
@@ -5,7 +5,7 @@ export const GET: RequestHandler = async ({ params }) => {
 	const { id } = params as { id: string };
 
 	if (!id || id.length < 17 || !/^\d+$/.test(id)) {
-		return new Response('Invalid Discord ID', { status: 400 });
+		return new Response(JSON.stringify({ success: false, error: 'Invalid Discord ID' }), { status: 400 });
 	}
 
 	const account = await GetAccountFromDiscord(id);

--- a/src/routes/api/account/discord/[id]/+server.ts
+++ b/src/routes/api/account/discord/[id]/+server.ts
@@ -1,0 +1,18 @@
+import { GetAccountFromDiscord } from '$db/database';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const { id } = params as { id: string };
+
+	if (!id || id.length < 17 || !/^\d+$/.test(id)) {
+		return new Response('Invalid Discord ID', { status: 400 });
+	}
+
+	const account = await GetAccountFromDiscord(id);
+
+	if (!account || !account.success) {
+		return new Response(JSON.stringify({ success: false, error: 'Account not found' }), { status: 404 });
+	}
+
+	return new Response(JSON.stringify(account));
+};


### PR DESCRIPTION
Adds a new API endpoint for fetching a player's minecraft account data from their Discord ID. Only returns a valid response when their ID is linked.

\+ `/api/account/discord/[id]`