### PR TITLE
Remove Unneeded Refresh Call

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,34 +1,3 @@
-import { PROFILE_UPDATE_INTERVAL } from './constants/data';
-import type { Profiles } from './skyblock';
-
-/**
- * Returns new profile data or `undefined` if the profile is not found or not updatable yet.
- */
-export async function FetchNewProfiles(uuid: string, last_fetched: number, delay = 2000) {
-	if (Date.now() - last_fetched < PROFILE_UPDATE_INTERVAL) {
-		return undefined;
-	}
-
-	// Wait for the delay
-	await new Promise((resolve) => setTimeout(resolve, delay));
-
-	const res = await fetch(`/api/profiles/${uuid}`);
-
-	if (res.status !== 200) {
-		return undefined;
-	}
-
-	try {
-		const data = (await res.json()) as Profiles;
-
-		if (data.success) {
-			return data;
-		}
-	} catch (e) {
-		return undefined;
-	}
-}
-
 export function RoundToFixed(num: number | null, fixed = 2) {
 	if (num === null || !isFinite(num)) return 0;
 

--- a/src/routes/stats/[id]/[profile]/+page.svelte
+++ b/src/routes/stats/[id]/[profile]/+page.svelte
@@ -6,7 +6,6 @@
 
 	import { DEFAULT_SKILL_CAPS } from '$lib/constants/levels';
 	import { getLevelProgress } from '$lib/format';
-	import { FetchNewProfiles } from '$lib/util';
 
 	import Skills from '$comp/stats/skills.svelte';
 	import PlayerInfo from '$comp/stats/playerinfo.svelte';
@@ -37,18 +36,9 @@
 
 	onMount(async () => {
 		const url = `/stats/${ign}/${profileName}`;
-		if ($page.url.pathname !== url)
+		if ($page.url.pathname !== url) {
 			history.replaceState(history.state, document.title, url + ($page.url.hash ?? ''));
-
-		// console.log(account);
-		// console.log({ profiles });
-		// console.log(data.weight);
-
-		// If the data is old, fetch new data and update the page.
-		FetchNewProfiles(uuid, data.last_fetched).then((data) => {
-			if (!data) return;
-			// profiles = data;
-		});
+		}
 	});
 
 	const weightStr =


### PR DESCRIPTION
Stop the client from requesting a refresh of the data when a page is fetched, it's now unneeded.