### PR TITLE
Fetch Single Profile

### DIFF
--- a/src/routes/api/profiles/[uuid]/[profileId]/+server.ts
+++ b/src/routes/api/profiles/[uuid]/[profileId]/+server.ts
@@ -15,9 +15,10 @@ export const GET: RequestHandler = async ({ params }) => {
 		return new Response(JSON.stringify({ error: "Hypixel API couldn't be reached." }), { status: 404 });
 	}
 
-	const profile = (profileId === 'selected') 
-		? profiles.profiles.find((profile) => profile.selected)
-		: profiles.profiles.find((profile) => profile.profile_id === profileId);
+	const profile =
+		profileId === 'selected'
+			? profiles.profiles.find((profile) => profile.selected)
+			: profiles.profiles.find((profile) => profile.profile_id === profileId);
 
 	if (!profile) {
 		return new Response(JSON.stringify({ error: 'Profile not found' }), { status: 404 });
@@ -28,7 +29,7 @@ export const GET: RequestHandler = async ({ params }) => {
 		last_fetched: profiles.last_fetched,
 		version: profiles.version,
 		profile: profile,
-	}
+	};
 
 	return new Response(JSON.stringify(data));
 };

--- a/src/routes/api/profiles/[uuid]/[profileId]/+server.ts
+++ b/src/routes/api/profiles/[uuid]/[profileId]/+server.ts
@@ -1,0 +1,34 @@
+import { fetchProfiles } from '$lib/data';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const uuid = params.uuid.replaceAll('-', '');
+	const profileId = params.profileId;
+
+	if (!uuid || uuid.length !== 32 || !profileId) {
+		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
+	}
+
+	const profiles = await fetchProfiles(uuid);
+
+	if (!profiles) {
+		return new Response(JSON.stringify({ error: "Hypixel API couldn't be reached." }), { status: 404 });
+	}
+
+	const profile = (profileId === 'selected') 
+		? profiles.profiles.find((profile) => profile.selected)
+		: profiles.profiles.find((profile) => profile.profile_id === profileId);
+
+	if (!profile) {
+		return new Response(JSON.stringify({ error: 'Profile not found' }), { status: 404 });
+	}
+
+	const data = {
+		success: true,
+		last_fetched: profiles.last_fetched,
+		version: profiles.version,
+		profile: profile,
+	}
+
+	return new Response(JSON.stringify(data));
+};

--- a/src/routes/stats/[id]/+page.ts
+++ b/src/routes/stats/[id]/+page.ts
@@ -1,5 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
-import type { AccountInfo, Profiles } from '$lib/skyblock';
+import type { AccountInfo, ProfileData } from '$lib/skyblock';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params, fetch }) => {
@@ -29,19 +29,17 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		throw redirect(303, '/');
 	}
 
-	const response = await fetch(`/api/profiles/${uuid}`);
+	const response = await fetch(`/api/profiles/${uuid}/selected`);
 
 	if (!response.ok) {
 		throw redirect(303, '/');
 	}
 
-	const data = (await response.json()) as Profiles;
+	const data = (await response.json()) as { profile: ProfileData, success: boolean };
 
-	// Get latest profile
-	const name = data.profiles.filter((a) => a.selected)[0]?.cute_name;
 
-	if (uuid && name) {
-		throw redirect(303, `/stats/${ign ?? uuid}/${name}`);
+	if (data.success) {
+		throw redirect(303, `/stats/${ign ?? uuid}/${encodeURIComponent(data.profile.cute_name)}`);
 	}
 
 	throw error(404, 'Skyblock profile not found for this player!');

--- a/src/routes/stats/[id]/+page.ts
+++ b/src/routes/stats/[id]/+page.ts
@@ -35,8 +35,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		throw redirect(303, '/');
 	}
 
-	const data = (await response.json()) as { profile: ProfileData, success: boolean };
-
+	const data = (await response.json()) as { profile: ProfileData; success: boolean };
 
 	if (data.success) {
 		throw redirect(303, `/stats/${ign ?? uuid}/${encodeURIComponent(data.profile.cute_name)}`);


### PR DESCRIPTION
Adds a `api/profiles/[uuid]/[profileId]` endpoint, for returning a single specified profile. `profileId` can also be substituted for "selected" which will return the active profile for that user.