### PR TITLE
Add Request Limit To `.env`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ REDIS_URI="redis://localhost:6379"
 REDIS_PASSWORD="redisCachePassword123"
 
 HYPIXEL_API_KEY="key-goes-here"
+HYPIXEL_KEY_REQUEST_LIMIT="60"
 DISCORD_CLIENT_SECRET="secret-goes-here"
 
 PUBLIC_DISCORD_CLIENT_ID="client-id-here"

--- a/src/lib/hypixel.ts
+++ b/src/lib/hypixel.ts
@@ -1,8 +1,15 @@
-import { HYPIXEL_API_KEY } from '$env/static/private';
+import { HYPIXEL_API_KEY, HYPIXEL_KEY_REQUEST_LIMIT } from '$env/static/private';
 import type { PlayerData, RawProfileResponse } from '$lib/skyblock';
 import { RateLimiter } from '$lib/limiter/RateLimiter';
 
-const limiter = new RateLimiter({ tokensPerInterval: 119, interval: 'minute' });
+let requestLimit = parseInt(HYPIXEL_KEY_REQUEST_LIMIT);
+
+if (isNaN(requestLimit)) {
+	console.error('HYPIXEL_KEY_REQUEST_LIMIT is not a number, defaulting to 60');
+	requestLimit = 60;
+}
+
+const limiter = new RateLimiter({ tokensPerInterval: requestLimit - 1, interval: 'minute' });
 
 interface NoSuccess {
 	success: false;


### PR DESCRIPTION
Makes the request limit for your key to be declared in the `.env` file.