### PR TITLE
Correct Cocoa Weight

### DIFF
--- a/src/lib/constants/weights.ts
+++ b/src/lib/constants/weights.ts
@@ -7,7 +7,7 @@ export const CROPS_PER_ONE_WEIGHT = {
 	pumpkin: 87_095.11,
 	melon: 435_466.47,
 	mushroom: 168_925.53,
-	cocoa: 303_091.99,
+	cocoa: 257_214.64,
 	cactus: 169_389.33,
 };
 


### PR DESCRIPTION
Correct cocoa weight. The cocoa chopper was mistakenly believed to give 1.2x drops, but it only gives 20 fortune.