### PR TITLE
Exclude Inventories from API Response By Default

### DIFF
--- a/src/routes/api/profiles/[uuid=uuid]/+server.ts
+++ b/src/routes/api/profiles/[uuid=uuid]/+server.ts
@@ -1,8 +1,10 @@
 import { fetchProfiles } from '$lib/data';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
 	const uuid = params.uuid.replaceAll('-', '');
+
+	const includeInventories = url.searchParams.get('inv') === 'true';
 
 	if (!uuid || uuid.length !== 32) {
 		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
@@ -12,6 +14,12 @@ export const GET: RequestHandler = async ({ params }) => {
 
 	if (!profiles) {
 		return new Response(JSON.stringify({ error: "Hypixel API couldn't be reached." }), { status: 404 });
+	}
+
+	if (!includeInventories) {
+		profiles.profiles.forEach((profile) => {
+			(profile.member as Omit<typeof profile.member, 'inventories'>).inventories = null;
+		});
 	}
 
 	return new Response(JSON.stringify(profiles));

--- a/src/routes/api/profiles/[uuid=uuid]/[profile]/+server.ts
+++ b/src/routes/api/profiles/[uuid=uuid]/[profile]/+server.ts
@@ -1,9 +1,11 @@
 import { fetchProfiles } from '$lib/data';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
 	const uuid = params.uuid.replaceAll('-', '');
 	const profileId = params.profile;
+
+	const includeInventories = url.searchParams.get('inv') === 'true';
 
 	if (!uuid || uuid.length !== 32 || !profileId) {
 		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
@@ -22,6 +24,10 @@ export const GET: RequestHandler = async ({ params }) => {
 
 	if (!profile) {
 		return new Response(JSON.stringify({ error: 'Profile not found' }), { status: 404 });
+	}
+
+	if (!includeInventories) {
+		(profile.member as Omit<typeof profile.member, 'inventories'>).inventories = null;
 	}
 
 	const data = {


### PR DESCRIPTION
The inventories field in the `/profiles` endpoint has been replaced by `null` if the `?inv=true` query parameter isn't present.