### PR TITLE
Refresh Profiles

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -264,7 +264,7 @@ export async function RefreshDataTask(limit = 250) {
 
 		Promise.allSettled([
 			// Room for more tasks here if ever needed
-			fetchProfiles(uuid),
+			fetchProfiles(uuid, true),
 		]).catch(() => undefined);
 	}
 

--- a/src/database/leaderboards.ts
+++ b/src/database/leaderboards.ts
@@ -338,12 +338,20 @@ export async function SetLeaderboard(category: string, page: string, entries: Le
 	}
 }
 
-export async function FetchLeaderboardRank(category: string, page: string, uuid: string, profile: string) {
+export async function FetchLeaderboardRank(
+	category: string,
+	page: string,
+	uuid: string,
+	profile: string,
+	skipUpdate = false
+) {
 	try {
 		const rank = await client.ZREVRANK(`${category}:${page}`, `${uuid}:${profile}`);
 
-		// Update their profile if it's stale
-		void fetchProfiles(uuid, true);
+		if (!skipUpdate) {
+			// Update their profile if it's stale
+			void fetchProfiles(uuid, true);
+		}
 
 		if (rank === null) return -1;
 
@@ -360,7 +368,7 @@ export async function FetchLeaderboardRankings(uuid: string, profile: string) {
 		const categoryPages = LEADERBOARDS[category]?.pages;
 
 		for (const page of Object.keys(categoryPages ?? {})) {
-			const rank = await FetchLeaderboardRank(category, page, uuid, profile);
+			const rank = await FetchLeaderboardRank(category, page, uuid, profile, true);
 
 			if (!rankings[category] as boolean) rankings[category] = {};
 			rankings[category][page] = rank;

--- a/src/database/leaderboards.ts
+++ b/src/database/leaderboards.ts
@@ -1,6 +1,7 @@
 import { LEADERBOARD_UPDATE_INTERVAL } from '$lib/constants/data';
 import { DBReady, sequelize } from '$db/database';
 import { client } from '$db/redis';
+import { fetchProfiles } from '$lib/data';
 export interface LeaderboardEntry {
 	ign: string;
 	uuid: string;
@@ -340,6 +341,9 @@ export async function SetLeaderboard(category: string, page: string, entries: Le
 export async function FetchLeaderboardRank(category: string, page: string, uuid: string, profile: string) {
 	try {
 		const rank = await client.ZREVRANK(`${category}:${page}`, `${uuid}:${profile}`);
+
+		// Update their profile if it's stale
+		void fetchProfiles(uuid, true);
 
 		if (rank === null) return -1;
 


### PR DESCRIPTION
Profiles will now be refreshed if queried via the rank endpoint. Also adds a `?showNext=true` query parameter to that endpoint to display who you're competing against.