### PR TITLE
Set cache control and use `return json(...)`

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,13 @@
 import { GetLeaderboardSlice } from '$db/leaderboards';
+import { LEADERBOARD_UPDATE_INTERVAL } from '$lib/constants/data';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ setHeaders }) => {
 	const lb = await GetLeaderboardSlice(0, 10, 'weight', 'farming');
+
+	setHeaders({
+		'Cache-Control': `max-age=${LEADERBOARD_UPDATE_INTERVAL / 1000}, public`,
+	});
 
 	return {
 		lb,

--- a/src/routes/api/[...catch]/+server.ts
+++ b/src/routes/api/[...catch]/+server.ts
@@ -1,5 +1,6 @@
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = () => {
-	return new Response(JSON.stringify({ success: false, error: 'Route not found.' }), { status: 404 });
+	return json({ success: false, error: 'Route not found.' }, { status: 404 });
 };

--- a/src/routes/api/account/[id]/+server.ts
+++ b/src/routes/api/account/[id]/+server.ts
@@ -1,7 +1,9 @@
+import { ACCOUNT_UPDATE_INTERVAL } from '$lib/constants/data';
 import { accountFromIGN, accountFromUUID } from '$lib/data';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const id = params.id.replaceAll('-', '');
 	const fromName = id.length < 17;
 
@@ -9,8 +11,12 @@ export const GET: RequestHandler = async ({ params }) => {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 	if (!account || (account as any).size === 0 || (account as any).errorMessage) {
-		return new Response('Account not found', { status: 404 });
+		return json({ success: false, error: 'Account not found' }, { status: 404 });
 	}
 
-	return new Response(JSON.stringify(account));
+	setHeaders({
+		'Cache-Control': `max-age=${ACCOUNT_UPDATE_INTERVAL / 1000}, public`,
+	});
+
+	return json(account);
 };

--- a/src/routes/api/account/discord/[id]/+server.ts
+++ b/src/routes/api/account/discord/[id]/+server.ts
@@ -1,18 +1,24 @@
 import { GetAccountFromDiscord } from '$db/database';
+import { ACCOUNT_UPDATE_INTERVAL } from '$lib/constants/data';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const { id } = params as { id: string };
 
 	if (!id || id.length < 17 || !/^\d+$/.test(id)) {
-		return new Response(JSON.stringify({ success: false, error: 'Invalid Discord ID' }), { status: 400 });
+		return json({ success: false, error: 'Invalid Discord ID' }, { status: 400 });
 	}
 
 	const account = await GetAccountFromDiscord(id);
 
 	if (!account?.success) {
-		return new Response(JSON.stringify({ success: false, error: 'Account not found' }), { status: 404 });
+		return json({ success: false, error: 'Account not found' }, { status: 404 });
 	}
 
-	return new Response(JSON.stringify(account));
+	setHeaders({
+		'Cache-Control': `max-age=${ACCOUNT_UPDATE_INTERVAL / 1000}, public`,
+	});
+
+	return json(account);
 };

--- a/src/routes/api/info/[uuid=uuid]/+server.ts
+++ b/src/routes/api/info/[uuid=uuid]/+server.ts
@@ -1,25 +1,31 @@
 import { GetUser } from '$db/database';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { UserInfo } from '$db/models/users';
+import { PROFILE_UPDATE_INTERVAL } from '$lib/constants/data';
 
-export const GET: RequestHandler = async (event) => {
-	const uuid = event.params.uuid.replaceAll('-', '');
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
+	const uuid = params.uuid.replaceAll('-', '');
 
 	if (!uuid || uuid.length !== 32) {
-		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
+		return json({ error: 'Not a valid UUID' }, { status: 400 });
 	}
 
 	const user = await GetUser(uuid);
 
 	if (!user) {
-		return new Response(JSON.stringify({ error: 'User not found' }), { status: 404 });
+		return json({ error: 'User not found' }, { status: 404 });
 	}
 
 	if (!user.info) {
-		return new Response(JSON.stringify({ error: 'User has no info' }), { status: 404 });
+		return json({ error: 'User has no info' }, { status: 404 });
 	}
+
+	setHeaders({
+		'Cache-Control': `max-age=${PROFILE_UPDATE_INTERVAL / 1000}, public`,
+	});
 
 	const info = user.info as Partial<UserInfo>;
 
-	return new Response(JSON.stringify(info));
+	return json(info);
 };

--- a/src/routes/api/leaderboard/rank/[category]/[page]/[uuid=uuid]/[[profile=uuid]]/+server.ts
+++ b/src/routes/api/leaderboard/rank/[category]/[page]/[uuid=uuid]/[[profile=uuid]]/+server.ts
@@ -23,7 +23,7 @@ export const GET: RequestHandler = async ({ params, url, setHeaders }) => {
 	const pageEntry = categoryEntry?.pages[page];
 
 	if (!pageEntry) {
-		return json({ success: false, error: 'Leaderboard not found' });
+		return json({ success: false, error: 'Leaderboard not found' }, { status: 404 });
 	}
 
 	setHeaders({
@@ -35,7 +35,7 @@ export const GET: RequestHandler = async ({ params, url, setHeaders }) => {
 		const player = await GetUser(uuid);
 
 		if (!player) {
-			return json({ success: false, error: 'Player not found' });
+			return json({ success: false, error: 'Player not found' }, { status: 404 });
 		}
 
 		let profileIds = player.skyblock?.profiles.map((p) => p.profile_id) ?? [];
@@ -45,7 +45,7 @@ export const GET: RequestHandler = async ({ params, url, setHeaders }) => {
 			profileIds = data?.profiles.map((p) => p.profile_id) ?? [];
 
 			if (profileIds.length === 0) {
-				return json({ success: false, error: 'Player has no profiles/not loaded yet' });
+				return json({ success: false, error: 'Player has no profiles/not loaded yet' }, { status: 404 });
 			}
 		}
 
@@ -62,7 +62,7 @@ export const GET: RequestHandler = async ({ params, url, setHeaders }) => {
 
 			return json({ success: true, ranks: ranksObj });
 		} catch (error) {
-			return json({ success: false, error: 'Error while fetching ranks.' });
+			return json({ success: false, error: 'Error while fetching ranks.' }, { status: 500 });
 		}
 	}
 
@@ -78,6 +78,6 @@ export const GET: RequestHandler = async ({ params, url, setHeaders }) => {
 
 		return json({ success: true, rank });
 	} catch (error) {
-		return json({ success: false, error: 'Error while fetching rank.' });
+		return json({ success: false, error: 'Error while fetching rank.' }, { status: 500 });
 	}
 };

--- a/src/routes/api/leaderboard/ranks/[uuid]/[profile]/+server.ts
+++ b/src/routes/api/leaderboard/ranks/[uuid]/[profile]/+server.ts
@@ -1,18 +1,23 @@
 import { FetchLeaderboardRankings } from '$db/leaderboards';
+import { LEADERBOARD_UPDATE_INTERVAL } from '$lib/constants/data';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const { uuid, profile } = params;
 
 	// Validate the UUID and profile UUID to be alphanumeric
 	if (!uuid || uuid.length !== 32 || !/^[a-zA-Z0-9_]+$/.test(uuid)) {
-		return json({ success: false, error: 'Invalid player UUID.' });
+		return json({ success: false, error: 'Invalid player UUID.' }, { status: 400 });
 	}
 
 	if (profile.length !== 32 || !/^[a-zA-Z0-9_]+$/.test(profile)) {
-		return json({ success: false, error: 'Invalid profile UUID.' });
+		return json({ success: false, error: 'Invalid profile UUID.' }, { status: 400 });
 	}
+
+	setHeaders({
+		'Cache-Control': `max-age=${LEADERBOARD_UPDATE_INTERVAL / 1000}, public`,
+	});
 
 	// Get the player's rank in each leaderboard
 	try {
@@ -20,6 +25,6 @@ export const GET: RequestHandler = async ({ params }) => {
 
 		return json({ success: true, ranks: rankings });
 	} catch (error) {
-		return json({ success: false, error: 'Error while fetching ranks.' });
+		return json({ success: false, error: 'Error while fetching ranks.' }, { status: 500 });
 	}
 };

--- a/src/routes/api/link/+server.ts
+++ b/src/routes/api/link/+server.ts
@@ -1,15 +1,12 @@
 import { GetUserByIGN, LinkDiscordUser, UnlinkDiscordUser } from '$db/database';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-
-export const GET: RequestHandler = () => {
-	return new Response(undefined, { status: 404 });
-};
 
 export const POST: RequestHandler = async ({ locals, request }) => {
 	const body = await request.text();
 
 	if (!locals.discordUser) {
-		return new Response('You must be logged in to link your account.', { status: 401 });
+		return json({ success: false, error: 'You must be logged in to link your account.' }, { status: 401 });
 	}
 
 	if (locals.discordUser.id && locals.user) {
@@ -19,12 +16,12 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			const uuid = locals.user.uuid;
 
 			if (!uuid) {
-				return new Response('Invalid UUID.', { status: 404 });
+				return json({ success: false, error: 'Invalid UUID.' }, { status: 404 });
 			}
 			await UnlinkDiscordUser(uuid);
-			return new Response(JSON.stringify({ success: true }));
+			return json({ success: true });
 		}
-		return new Response(JSON.stringify(locals.user));
+		return json(locals.user);
 	}
 
 	const input = body.replace('username=', '');
@@ -32,28 +29,28 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 	// Check if the username is a valid minecraft username.
 	if (!username?.match(/^[a-zA-Z0-9_]{1,16}$/)) {
-		return new Response('Invalid username.', { status: 404 });
+		return json({ success: false, error: 'Invalid username.' }, { status: 404 });
 	}
 
 	const foundUser = await GetUserByIGN(username);
 
 	if (!foundUser) {
-		return new Response('User not found.', { status: 404 });
+		return json({ success: false, error: 'User not found.' }, { status: 404 });
 	}
 
 	const linkedName = foundUser.player?.player.socialMedia?.links?.DISCORD;
 
 	if (!linkedName) {
-		return new Response("User doesn't have a linked account on Hypixel.", { status: 404 });
+		return json({ success: false, error: "User doesn't have a linked account on Hypixel." }, { status: 404 });
 	}
 
 	const discordUser = `${locals.discordUser.username}#${locals.discordUser.discriminator}`;
 
 	if (discordUser !== linkedName) {
-		return new Response('User has a different account linked.', { status: 401 });
+		return json({ success: false, error: 'User has a different account linked.' }, { status: 401 });
 	}
 
 	// Success!
 	await LinkDiscordUser(foundUser.uuid, locals.discordUser);
-	return new Response(JSON.stringify(foundUser));
+	return json(foundUser);
 };

--- a/src/routes/api/player/[uuid=uuid]/+server.ts
+++ b/src/routes/api/player/[uuid=uuid]/+server.ts
@@ -1,20 +1,25 @@
+import { ACCOUNT_UPDATE_INTERVAL } from '$lib/constants/data';
 import { fetchPlayer } from '$lib/data';
-import { error } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const uuid = params.uuid.replaceAll('-', '');
 
 	if (!uuid || uuid.length !== 32) {
-		throw error(400, 'Not a valid UUID');
+		return json({ success: false, error: 'Not a valid UUID' }, { status: 400 });
 	}
 
 	const player = await fetchPlayer(uuid);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 	if (!player || (player as any).size === 0) {
-		throw error(404, "Hypixel API couldn't be reached.");
+		return json({ success: false, error: "Player not found or Hypixel API couldn't be reached." }, { status: 404 });
 	}
 
-	return new Response(JSON.stringify(player));
+	setHeaders({
+		'Cache-Control': `max-age=${ACCOUNT_UPDATE_INTERVAL / 1000}, public`,
+	});
+
+	return json(player);
 };

--- a/src/routes/api/profiles/[uuid=uuid]/+server.ts
+++ b/src/routes/api/profiles/[uuid=uuid]/+server.ts
@@ -1,4 +1,5 @@
 import { fetchProfiles } from '$lib/data';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, url }) => {
@@ -7,13 +8,13 @@ export const GET: RequestHandler = async ({ params, url }) => {
 	const includeInventories = url.searchParams.get('inv') === 'true';
 
 	if (!uuid || uuid.length !== 32) {
-		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
+		return json({ success: false, error: 'Not a valid UUID' }, { status: 400 });
 	}
 
 	const profiles = await fetchProfiles(uuid);
 
 	if (!profiles) {
-		return new Response(JSON.stringify({ error: "Hypixel API couldn't be reached." }), { status: 404 });
+		return json({ success: false, error: "Hypixel API couldn't be reached." }, { status: 404 });
 	}
 
 	if (!includeInventories) {
@@ -22,5 +23,5 @@ export const GET: RequestHandler = async ({ params, url }) => {
 		});
 	}
 
-	return new Response(JSON.stringify(profiles));
+	return json(profiles);
 };

--- a/src/routes/api/refresh/+server.ts
+++ b/src/routes/api/refresh/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types';
 import { PUBLIC_DISCORD_CLIENT_ID, PUBLIC_DISCORD_REDIRECT_ROUTE } from '$env/static/public';
 import { DISCORD_CLIENT_SECRET } from '$env/static/private';
 import crypto from 'crypto';
+import { json } from '@sveltejs/kit';
 
 const DISCORD_CLIENT_ID = PUBLIC_DISCORD_CLIENT_ID;
 
@@ -11,9 +12,12 @@ export const GET: RequestHandler = async ({ url }) => {
 	const uuid = crypto.randomUUID();
 
 	if (!refreshToken) {
-		return new Response(JSON.stringify({ error: 'No refresh token found' }), {
-			status: 404,
-		});
+		return json(
+			{ error: 'No refresh token found' },
+			{
+				status: 404,
+			}
+		);
 	}
 
 	const data = {
@@ -44,29 +48,30 @@ export const GET: RequestHandler = async ({ url }) => {
 	};
 
 	if (response.error) {
-		return new Response(JSON.stringify({ error: response.error }), {
-			status: 400,
-		});
+		return json(
+			{ error: response.error },
+			{
+				status: 400,
+			}
+		);
 	}
 
 	const accessTokenExpires = new Date(Date.now() + response.expires_in); // ~10 minutes
 	const refreshTokenExpires = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days
 
-	return new Response(
-		JSON.stringify({
-			discord_access_token: response.access_token,
-			cookies: [
-				{
-					name: 'discord_access_token',
-					value: response.access_token,
-					expires: accessTokenExpires.toUTCString(),
-				},
-				{
-					name: 'discord_refresh_token',
-					value: response.refresh_token,
-					expires: refreshTokenExpires.toUTCString(),
-				},
-			],
-		})
-	);
+	return json({
+		discord_access_token: response.access_token,
+		cookies: [
+			{
+				name: 'discord_access_token',
+				value: response.access_token,
+				expires: accessTokenExpires.toUTCString(),
+			},
+			{
+				name: 'discord_refresh_token',
+				value: response.refresh_token,
+				expires: refreshTokenExpires.toUTCString(),
+			},
+		],
+	});
 };

--- a/src/routes/api/similar/[input=ign]/+server.ts
+++ b/src/routes/api/similar/[input=ign]/+server.ts
@@ -1,14 +1,19 @@
 import { FindSimilarUsers } from '$db/database';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const input = params.input.replaceAll('-', '');
 
 	const names = (await FindSimilarUsers(input)) as { ign: string; similarity: number }[] | null;
 
 	if (!names) {
-		return new Response(JSON.stringify({ error: "Database couldn't be reached" }), { status: 404 });
+		return json({ success: false, error: "Database couldn't be reached" }, { status: 404 });
 	}
 
-	return new Response(JSON.stringify({ success: true, players: names }));
+	setHeaders({
+		'Cache-Control': `max-age=86400, public`,
+	});
+
+	return json({ success: true, players: names });
 };

--- a/src/routes/api/weight/[uuid=uuid]/[profile=uuid]/+server.ts
+++ b/src/routes/api/weight/[uuid=uuid]/[profile=uuid]/+server.ts
@@ -1,13 +1,15 @@
 import { GetUser } from '$db/database';
 import type { UserInfo } from '$db/models/users';
+import { PROFILE_UPDATE_INTERVAL } from '$lib/constants/data';
 import { accountFromUUID, fetchProfiles } from '$lib/data';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
 	const uuid = params.uuid.replaceAll('-', '');
 
 	if (!uuid || uuid.length !== 32) {
-		return new Response(JSON.stringify({ error: 'Not a valid UUID' }), { status: 400 });
+		return json({ success: false, error: 'Not a valid UUID' }, { status: 400 });
 	}
 
 	let user = await GetUser(uuid);
@@ -17,29 +19,38 @@ export const GET: RequestHandler = async ({ params }) => {
 		const account = await accountFromUUID(uuid);
 
 		if (!account) {
-			return new Response(JSON.stringify({ error: 'Account not found' }), { status: 404 });
+			return json({ success: false, error: 'Account not found' }, { status: 404 });
 		}
 
 		await fetchProfiles(uuid);
 		user = await GetUser(uuid);
 
 		if (!user) {
-			return new Response(JSON.stringify({ error: 'User not found' }), { status: 404 });
+			return json({ success: false, error: 'User not found' }, { status: 404 });
 		}
 	}
 
 	const profilesData = await fetchProfiles(uuid);
 
 	if (!profilesData?.success) {
-		return new Response(JSON.stringify({ error: 'Profiles not found' }), { status: 404 });
+		return json({ success: false, error: 'Profiles not found' }, { status: 404 });
 	}
 
 	const info = user.info as Partial<UserInfo> | undefined;
 
 	if (!info) {
-		return new Response(JSON.stringify({ error: 'User info not found' }), { status: 404 });
+		return json({ success: false, error: 'User info not found' }, { status: 404 });
 	}
 
 	const profile = info.profiles?.[params.profile];
-	return new Response(JSON.stringify(profile ?? { error: 'Profile not found.' }), { status: profile ? 200 : 404 });
+
+	if (!profile) {
+		return json({ success: false, error: 'Profile not found' }, { status: 404 });
+	}
+
+	setHeaders({
+		'Cache-Control': `max-age=${PROFILE_UPDATE_INTERVAL / 1000}, public`,
+	});
+
+	return json(profile);
 };

--- a/src/routes/leaderboard/+page.server.ts
+++ b/src/routes/leaderboard/+page.server.ts
@@ -20,7 +20,7 @@ export const load: PageServerLoad = ({ setHeaders }) => {
 	});
 
 	setHeaders({
-		'Cache-Control': 'max-age=600',
+		'Cache-Control': 'max-age=86400, public',
 	});
 
 	return {

--- a/src/routes/leaderboard/[category]/[page]/[[start]]/+page.server.ts
+++ b/src/routes/leaderboard/[category]/[page]/[[start]]/+page.server.ts
@@ -1,5 +1,6 @@
 import { GetUser, GetUserByIGN } from '$db/database';
 import { FetchLeaderboardRank, GetLeaderboardSlice, LeaderboardCategories, LEADERBOARDS } from '$db/leaderboards';
+import { LEADERBOARD_UPDATE_INTERVAL } from '$lib/constants/data';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -56,7 +57,7 @@ export const load: PageServerLoad = async ({ params, depends, setHeaders }) => {
 	const name = pageEntry?.name ?? categoryEntry?.name ?? 'Leaderboard';
 
 	setHeaders({
-		'Cache-Control': 'max-age=300',
+		'Cache-Control': `max-age=${LEADERBOARD_UPDATE_INTERVAL / 1000}, public`,
 	});
 
 	return {

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -50,8 +50,8 @@
 			user = !skip;
 			location.reload();
 		} else {
-			const data = await response.text();
-			errorMessage = data;
+			const data = await response.json();
+			errorMessage = data.error ?? 'An unknown error occurred';
 		}
 	};
 </script>

--- a/src/routes/stats/[id=id]/[profile]/+page.server.ts
+++ b/src/routes/stats/[id=id]/[profile]/+page.server.ts
@@ -6,8 +6,9 @@ import FarmingCollections from '$lib/collections';
 import type { PlayerInfo, Profiles } from '$lib/skyblock';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { PROFILE_UPDATE_INTERVAL } from '$lib/constants/data';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
 	const { id } = params;
 	const accountData = await accountFromId(id);
 
@@ -80,6 +81,10 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		}
 
 		const rankings = await FetchLeaderboardRankings(account.id, profile.profile_id);
+
+		setHeaders({
+			'Cache-Control': `max-age=${PROFILE_UPDATE_INTERVAL / 1000}, public`,
+		});
 
 		return {
 			account: account,


### PR DESCRIPTION
Set a public cache control header where appropriate and changed all `return new Resonse(JSON.stringify(...))` responses to use the built-in `return json(...)` which also corrects the data type being sent.