### PR TITLE
Garden 1.5 Balance

### DIFF
--- a/src/lib/constants/weights.ts
+++ b/src/lib/constants/weights.ts
@@ -5,7 +5,7 @@ export const CROPS_PER_ONE_WEIGHT = {
 	sugarcane: 200_000,
 	netherwart: 250_000,
 	pumpkin: 90_066.27,
-	melon: 450_324.60,
+	melon: 450_324.6,
 	mushroom: 90_178.06,
 	cocoa: 267_174.04,
 	cactus: 177_254.45,

--- a/src/lib/constants/weights.ts
+++ b/src/lib/constants/weights.ts
@@ -4,11 +4,11 @@ export const CROPS_PER_ONE_WEIGHT = {
 	potato: 300_000,
 	sugarcane: 200_000,
 	netherwart: 250_000,
-	pumpkin: 87_095.11,
-	melon: 435_466.47,
-	mushroom: 168_925.53,
-	cocoa: 257_214.64,
-	cactus: 169_389.33,
+	pumpkin: 90_066.27,
+	melon: 450_324.60,
+	mushroom: 90_178.06,
+	cocoa: 267_174.04,
+	cactus: 177_254.45,
 };
 
 // Bonus

--- a/src/routes/info/+page.svelte
+++ b/src/routes/info/+page.svelte
@@ -30,9 +30,7 @@
 			<p class="text-sm mt-4 mb-2">
 				Base Drops Per Break refers to the average amount of drops you get from breaking a crop without any
 				buffs. Sugar Cane and Cactus actually have a base drop of 1 per block, but because you can break 2
-				blocks at once, 2 is noted here. Mushroom is also nerfed more to make up for the Mooshroom cow perk; one
-				hour of perfect farming would net you an extra one weight with the current value. Full calculation
-				breakdowns will be added in the future.
+				blocks at once, 2 is noted here. Full calculation breakdowns will be added in the future.
 			</p>
 			<p class="text-sm">
 				* Mushroom weight is calculated dynamically because of the Mooshroom Cow pet. Because Cactus and Sugar


### PR DESCRIPTION
Axe crops got a very mild nerf because of the Mossy Fermento Helm being better than Lantern, and Mushroom was buffed to be almost double with the Fungi cutter being fixed.