### PR TITLE
Add Endpoint to Get Current Crop Weights

### DIFF
--- a/src/routes/api/weights/+server.ts
+++ b/src/routes/api/weights/+server.ts
@@ -1,0 +1,11 @@
+import { CROPS_PER_ONE_WEIGHT } from '$lib/constants/weights';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ setHeaders }) => {
+	setHeaders({
+		'Cache-Control': 'max-age=86400, public', // 1 day
+	});
+
+	return json({ success: true, crops: CROPS_PER_ONE_WEIGHT });
+};


### PR DESCRIPTION
Adds a self explanatory `/weights` api endpoint to get the crop weights.

https://elitebot.dev/api/weights